### PR TITLE
add deprecation notice to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# !! DEPRECATED !!
+This repository is deprecated. Official support for the Prometheus exporter for Synse Server now lives in the [Synse GraphQL](https://github.com/vapor-ware/synse-graphql) repository.
+
+-------------------------
+
+
 synse-prometheus provides a [Prometheus][prometheus] exporter for the metrics being provided by your data center and IT equipment. You can use this, in conjunction with Prometheus to monitor these metrics and alert on them.
 
 # Kick the tires


### PR DESCRIPTION
**Review Deadline**: --

## Summary
A while back, the prometheus exporter moved to the Synse GraphQL repo, where it now lives and is maintained. That makes this repo obsolete. This adds a deprecation notice to the top of the repo README.